### PR TITLE
Introduce strict ordered signal

### DIFF
--- a/Monitor.xcodeproj/project.pbxproj
+++ b/Monitor.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		445B72F924708599000615E9 /* StrictOrderedSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B72F824708599000615E9 /* StrictOrderedSignal.swift */; };
+		445B72FB2470866B000615E9 /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B72FA2470866B000615E9 /* Stack.swift */; };
+		445B72FD24708737000615E9 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B72FC24708737000615E9 /* Queue.swift */; };
+		445B72FF247088B9000615E9 /* StrictOrderedSignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445B72FE247088B9000615E9 /* StrictOrderedSignalTests.swift */; };
 		A5001DFE22BAA5E600106821 /* ManualDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001DFD22BAA5E600106821 /* ManualDispatcher.swift */; };
 		A5001E0222BAB0ED00106821 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001E0122BAB0ED00106821 /* Either.swift */; };
 		A5001E0522BAD98A00106821 /* ConcurrencyLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001E0422BAD98A00106821 /* ConcurrencyLimiter.swift */; };
@@ -143,6 +147,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		445B72F824708599000615E9 /* StrictOrderedSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrictOrderedSignal.swift; sourceTree = "<group>"; };
+		445B72FA2470866B000615E9 /* Stack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
+		445B72FC24708737000615E9 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		445B72FE247088B9000615E9 /* StrictOrderedSignalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrictOrderedSignalTests.swift; sourceTree = "<group>"; };
 		A5001DFD22BAA5E600106821 /* ManualDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualDispatcher.swift; sourceTree = "<group>"; };
 		A5001E0122BAB0ED00106821 /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
 		A5001E0422BAD98A00106821 /* ConcurrencyLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrencyLimiter.swift; sourceTree = "<group>"; };
@@ -453,6 +461,8 @@
 				A574CB1122E3B2DC0051E8F5 /* TerminalInterceptor.swift */,
 				A52D99C323019B6A0053D66D /* OnDemand.swift */,
 				A51EE48623107D0200B278E9 /* Weak.swift */,
+				445B72FA2470866B000615E9 /* Stack.swift */,
+				445B72FC24708737000615E9 /* Queue.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -502,6 +512,7 @@
 				A5EBD5172293E64C00701AB9 /* MonitorTests.swift */,
 				A5EBD52C22959D3100701AB9 /* MonitorTransformationTests.swift */,
 				A55498E722E4CB9600C5E8DA /* MonitorHeterogeneousMixTests.swift */,
+				445B72FE247088B9000615E9 /* StrictOrderedSignalTests.swift */,
 				A5EBD5082291FBF300701AB9 /* Info.plist */,
 			);
 			path = MonitorTests;
@@ -521,6 +532,7 @@
 				A5EBD5272295940C00701AB9 /* Monitor+transform.swift */,
 				A574CA8322C3C7890051E8F5 /* Monitor+hetorogeneusMix.swift */,
 				A5407F6822C0B8B400F24D21 /* Monitor+homogeneusMix.swift */,
+				445B72F824708599000615E9 /* StrictOrderedSignal.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -733,6 +745,7 @@
 				A52D99F22305FA960053D66D /* Monitor+reduceFlatMap.swift in Sources */,
 				A52EB493231F9C4E0093B501 /* ContextAccessor.swift in Sources */,
 				A5A54AF922A5440B00EC87F7 /* Monitor+flatMap.swift in Sources */,
+				445B72FD24708737000615E9 /* Queue.swift in Sources */,
 				A52D99C423019B6A0053D66D /* OnDemand.swift in Sources */,
 				A51EE4B623141FE800B278E9 /* Monitor+rewire.swift in Sources */,
 				A52AB41423283D8B0057AA9A /* ObservableValue+AdditiveArithmetic.swift in Sources */,
@@ -747,6 +760,7 @@
 				A51EE4A02312827400B278E9 /* first.swift in Sources */,
 				A51EE48523107BA500B278E9 /* Vanished.swift in Sources */,
 				A5001E0E22BBD17C00106821 /* ThreadSafetyStrategy.swift in Sources */,
+				445B72FB2470866B000615E9 /* Stack.swift in Sources */,
 				A574CA9F22DE0B510051E8F5 /* ObservableValue.swift in Sources */,
 				A52EB489231DAC2B0093B501 /* Vanishable+associateInContext.swift in Sources */,
 				A574CA9422C74EB20051E8F5 /* Transferer.swift in Sources */,
@@ -780,6 +794,7 @@
 				A5FDAB7222BA639B003ECB66 /* Monitor+transfer.swift in Sources */,
 				A5EBD52B229599C900701AB9 /* Monitor+map.swift in Sources */,
 				A574CAA122DE0C250051E8F5 /* ObservableValueWasDisposed.swift in Sources */,
+				445B72F924708599000615E9 /* StrictOrderedSignal.swift in Sources */,
 				A51EE47D231008F900B278E9 /* QueueDispatcher.swift in Sources */,
 				A51EE48B23107FEC00B278E9 /* Monitor+distinct.swift in Sources */,
 				A5001E1322BBD6DE00106821 /* DispatcherThreadSafety.swift in Sources */,
@@ -806,6 +821,7 @@
 				A51EE4B023131F6300B278E9 /* Example4.swift in Sources */,
 				E72829D8240C3B85008BCA75 /* ManualDispatcher.HighConcurrency.swift in Sources */,
 				E74CD1A72427EA7900C2DBAC /* MonitorDistinctTests.swift in Sources */,
+				445B72FF247088B9000615E9 /* StrictOrderedSignalTests.swift in Sources */,
 				A5001DFE22BAA5E600106821 /* ManualDispatcher.swift in Sources */,
 				A51EE4942311AE1800B278E9 /* Example3.swift in Sources */,
 				A5EBD5182293E64C00701AB9 /* MonitorTests.swift in Sources */,

--- a/Monitor/Core/Internal/Queue.swift
+++ b/Monitor/Core/Internal/Queue.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct Queue<Element> {
+    init() {
+        input = Stack()
+        output = Stack()
+    }
+
+    init<U: Sequence>(_ sequence: U) where U.Element == Element {
+        input = Stack()
+        output = Stack(sequence.reversed())
+    }
+
+    /// A Boolean value indicating whether the queue is empty.
+    /// - Complexity: O(1)
+    var isEmpty: Bool {
+        input.isEmpty && output.isEmpty
+    }
+
+    /// First element of the queue if it's not empty, otherwise `nil`
+    /// - Complexity: O(1) on average
+    var peek: Element? {
+        let (_, output) = shift(input: input, output: self.output)
+        return output.peek
+    }
+
+    /// Adds an element to the end of the queue
+    ///
+    /// - Parameter t: The element to be added to a queue
+    /// - Complexity: O(1)
+    mutating func push(_ object: Element) {
+        input.push(object)
+    }
+
+    /// Removes and returns the first element of the queue
+    ///
+    /// - Returns: First element of the queue if it's not empty, otherwise `nil`
+    /// - Complexity: O(1) on average
+    mutating func pop() -> Element? {
+        prepareOutput()
+        return output.pop()
+    }
+
+    /// Removes and returns all elements of the queue
+    ///
+    /// - Returns: Array with queue elements in dequeue order
+    /// - Complexity: O(n) where n is an amount of elements in a queue
+    mutating func popAll() -> [Element] {
+        prepareOutput()
+        var result = [Element]()
+        while let value = output.pop() {
+            result.append(value)
+        }
+        return result
+    }
+
+    /// The number of elements in the queue
+    /// - Complexity: O(1)
+    var count: Int {
+        input.count + output.count
+    }
+
+    private mutating func prepareOutput() {
+        (input, output) = shift(input: input, output: output)
+    }
+
+    private var input: Stack<Element>
+    private var output: Stack<Element>
+}
+
+extension Array {
+    init(_ queue: Queue<Element>) {
+        var copy = queue
+        self = copy.popAll()
+    }
+}
+
+private func shift<T>(input: Stack<T>, output: Stack<T>) -> (Stack<T>, Stack<T>) {
+    guard output.isEmpty else { return (input, output) }
+    var inputResult = input
+    var outputResult = output
+    while let value = inputResult.pop() {
+        outputResult.push(value)
+    }
+    return (inputResult, outputResult)
+}

--- a/Monitor/Core/Internal/Stack.swift
+++ b/Monitor/Core/Internal/Stack.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct Stack<Element> {
+    init() {
+        array = []
+    }
+
+    init<U: Sequence>(_ sequence: U) where U.Element == Element {
+        array = Array(sequence)
+    }
+
+    /// Adds an element to the top of the stack
+    ///
+    /// - Parameter t: The element to be added to a stack
+    /// - Complexity: O(1)
+    mutating func push(_ t: Element) {
+        array.append(t)
+    }
+
+    /// Removes and returns the top element of the stack
+    ///
+    /// - Returns: Top element of the stack if it's not empty, otherwise `nil`
+    /// - Complexity: O(1)
+    mutating func pop() -> Element? {
+        array.popLast()
+    }
+
+    /// Top element of the stack if it's not empty, otherwise `nil`
+    /// - Complexity: O(1)
+    var peek: Element? {
+        array.last
+    }
+
+    /// A Boolean value indicating whether the stack is empty.
+    /// - Complexity: O(1)
+    var isEmpty: Bool {
+        array.isEmpty
+    }
+
+    /// The number of elements in the stack
+    /// - Complexity: O(1) due to inner array being RandomAccessCollection
+    var count: Int {
+        array.count
+    }
+
+    private var array: [Element]
+}

--- a/Monitor/Core/StrictOrderedSignal.swift
+++ b/Monitor/Core/StrictOrderedSignal.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public final class StrictOrderedSignal<Ephemeral, Terminal> {
+    public static func create(
+        of _: Ephemeral.Type = Ephemeral.self,
+        _: Terminal.Type = Terminal.self
+    ) -> (Monitor<Ephemeral, Terminal>, StrictOrderedSignal) {
+        let (monitor, feed) = Monitor.make(of: Ephemeral.self, Terminal.self)
+        let signal = Self(monitor: monitor, feed: feed)
+        return (monitor, signal)
+    }
+
+    public private(set) weak var monitor: Monitor<Ephemeral, Terminal>?
+
+    public func emit(ephemeral: Ephemeral) {
+        switch pending {
+        case .none:
+            propagate(ephemeral: ephemeral, pendingEphemerals: Queue())
+        case var .ephemeral(pendingEphemerals):
+            pendingEphemerals.push(ephemeral)
+            pending = .ephemeral(pendingEphemerals)
+        case .terminal:
+            break
+        }
+    }
+
+    public func terminate(with terminal: Terminal) {
+        switch pending {
+        case .none:
+            internalTerminate(with: terminal)
+        case .ephemeral:
+            pending = .terminal(terminal)
+        case .terminal:
+            break
+        }
+    }
+
+    public func cancelled(callback: @escaping Action) {
+        feed.addCancelationObserver(onCancel: callback)
+    }
+
+    private init(
+        monitor: Monitor<Ephemeral, Terminal>,
+        feed: Feed<Ephemeral, Terminal>
+    ) {
+        self.feed = feed
+        self.monitor = monitor
+    }
+
+    private func propagate(ephemeral: Ephemeral, pendingEphemerals: Queue<Ephemeral>) {
+        pending = .ephemeral(pendingEphemerals)
+        feed.push(ephemeral: ephemeral)
+        onPropagationComplete()
+    }
+
+    private func internalTerminate(with terminal: Terminal) {
+        pending = nil
+        feed.push(terminal: terminal)
+    }
+
+    private func onPropagationComplete() {
+        switch pending {
+        case var .ephemeral(pendingEphemerals):
+            if let ephemeral = pendingEphemerals.pop() {
+                propagate(ephemeral: ephemeral, pendingEphemerals: pendingEphemerals)
+            } else {
+                pending = nil
+            }
+        case let .terminal(terminal):
+            internalTerminate(with: terminal)
+        case .none:
+            break
+        }
+    }
+
+    private enum Pending {
+        case ephemeral(Queue<Ephemeral>)
+        case terminal(Terminal)
+    }
+
+    private var pending: Pending?
+    private let feed: Feed<Ephemeral, Terminal>
+}

--- a/MonitorTests/StrictOrderedSignalTests.swift
+++ b/MonitorTests/StrictOrderedSignalTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import XCTest
+import Monitor
+
+final class StrictOrderedSignalTest: XCTestCase {
+    func test_ephemeralPushInsideObservation_DoesNotAffectEphemeralPropagationOrder() {
+        let (monitor, signal) = StrictOrderedSignal.create(of: Int.self, Int.self)
+        var events1 = [] as [Int]
+        var events2 = [] as [Int]
+
+        let token1 = monitor.observe(ephemeral: { value in
+            events1.append(value)
+            if value % 2 == 0 {
+                signal.emit(ephemeral: value + 1)
+            }
+        }, terminal: pass)
+
+        let token2 = monitor.observe(ephemeral: { value in
+            events2.append(value)
+        }, terminal: pass)
+
+        (0...3).map { $0 * 2 }.forEach(signal.emit(ephemeral:))
+
+        let expected = [0, 1, 2, 3, 4, 5, 6, 7]
+        XCTAssertEqual(events1, expected)
+        XCTAssertEqual(events2, expected)
+
+        [token1, token2].forEach { $0.cancel() }
+    }
+
+    func test_terminalPushInsideObservation_DoesNotAffectPropagationOrder() {
+        let (monitor, signal) = StrictOrderedSignal.create(of: Int.self, Int.self)
+        var events1 = [] as [Int]
+        var events2 = [] as [Int]
+
+        let token1 = monitor.observe(ephemeral: { value in
+            events1.append(value)
+            signal.terminate(with: 25)
+        }, terminal: { value in
+            events1.append(value)
+        })
+
+        let token2 = monitor.observe(ephemeral: { value in
+            events2.append(value)
+        }, terminal: { value in
+            events2.append(value)
+        })
+
+        signal.emit(ephemeral: 0)
+
+        let expected = [0, 25]
+        XCTAssertEqual(events1, expected)
+        XCTAssertEqual(events2, expected)
+
+        [token1, token2].forEach { $0.cancel() }
+    }
+
+    func test_subscribtionInsideObservation_doesNotReceiveCurrentEvent() {
+        let (monitor, signal) = StrictOrderedSignal.create(of: Int.self, Int.self)
+        var events1 = [] as [Int]
+        var events2 = [] as [Int]
+        var events3 = [] as [Int]
+
+        var token3: Vanishable?
+
+        let token1 = monitor.observe(ephemeral: { value in
+            events1.append(value)
+            token3 = monitor.observe(ephemeral: { value in
+                events3.append(value)
+            }, terminal: pass)
+        }, terminal: pass)
+
+        let token2 = monitor.observe(ephemeral: { value in
+            events2.append(value)
+        }, terminal: pass)
+
+        signal.emit(ephemeral: 1)
+
+        XCTAssertEqual(events1, [1])
+        XCTAssertEqual(events2, [1])
+        XCTAssertEqual(events3, [])
+
+        [token1, token2, token3].forEach { $0?.cancel() }
+    }
+
+    func test_ephemeralPushedInObservation_followedByTerminal_areDiscarded() {
+        let (monitor, signal) = StrictOrderedSignal.create(of: Int.self, Int.self)
+        var events1 = [] as [Int]
+        var events2 = [] as [Int]
+        var events3 = [] as [Int]
+
+        let token1 = monitor.observe(ephemeral: { value in
+            events1.append(value)
+            signal.emit(ephemeral: 2)
+        }, terminal: { value in
+            events1.append(value)
+        })
+
+        let token2 = monitor.observe(ephemeral: { value in
+            events2.append(value)
+            signal.emit(ephemeral: 3)
+        }, terminal: { value in
+            events2.append(value)
+        })
+
+        let token3 = monitor.observe(ephemeral: { value in
+            events3.append(value)
+            signal.terminate(with: 25)
+        }, terminal: { value in
+            events3.append(value)
+        })
+
+        signal.emit(ephemeral: 1)
+
+        let expected = [1, 25]
+        XCTAssertEqual(events1, expected)
+        XCTAssertEqual(events2, expected)
+        XCTAssertEqual(events3, expected)
+
+        [token1, token2, token3].forEach { $0?.cancel() }
+    }
+
+    func test_terminalSubscriptionInTerminalObservation_receivesTerminal() {
+        let (monitor, signal) = StrictOrderedSignal.create(of: Int.self, Int.self)
+        var events1 = [] as [Int]
+        var events2 = [] as [Int]
+        var events3 = [] as [Int]
+
+        var token3: Vanishable?
+
+        let token1 = monitor.observe(ephemeral: pass, terminal: { value in
+            events1.append(value)
+            token3 = monitor.observe(ephemeral: pass, terminal: { value in
+                events3.append(value)
+            })
+        })
+
+        let token2 = monitor.observe(ephemeral: pass, terminal: { value in
+            events2.append(value)
+        })
+
+        signal.terminate(with: 0)
+
+        let expected = [0]
+        XCTAssertEqual(events1, expected)
+        XCTAssertEqual(events2, expected)
+        XCTAssertEqual(events3, expected)
+
+        [token1, token2, token3].forEach { $0?.cancel() }
+    }
+
+    func test_disposeSubscriptionInTerminalObservation_receivesEvent() {
+        let (monitor, signal) = StrictOrderedSignal.create(of: Int.self, Int.self)
+        var events1 = [] as [Int]
+        var events2 = [] as [Int]
+        var events3 = [] as [Int]
+
+        let token1 = monitor.observe(ephemeral: pass, terminal: { value in
+            events1.append(value)
+            signal.cancelled {
+                events3.append(25)
+            }
+        })
+
+        let token2 = monitor.observe(ephemeral: pass, terminal: { value in
+            events2.append(value)
+        })
+
+        signal.terminate(with: 0)
+
+        let expected = [0]
+        XCTAssertEqual(events1, expected)
+        XCTAssertEqual(events2, expected)
+        XCTAssertEqual(events3, [25])
+
+        [token1, token2].forEach { $0?.cancel() }
+    }
+}
+
+private func pass<T>(_: T) { }


### PR DESCRIPTION
Strict ordered signal is used to ensure ordered ephemeral propagation in case of pushing inside observation.